### PR TITLE
fix: [RBAC] use full hash for grantee ID

### DIFF
--- a/internal/metastore/kv/rootcoord/kv_catalog.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog.go
@@ -1044,6 +1044,7 @@ func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvus
 	var (
 		privilegeName = entity.Grantor.Privilege.Name
 		k             = funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", entity.Role.Name, entity.Object.Name, funcutil.CombineObjectName(entity.DbName, entity.ObjectName)))
+		granteeKey    = k
 		idStr         string
 		v             string
 		err           error
@@ -1051,8 +1052,10 @@ func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvus
 
 	// Compatible with logic without db
 	if entity.DbName == util.DefaultDBName {
-		v, err = kc.Txn.Load(funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", entity.Role.Name, entity.Object.Name, entity.ObjectName)))
+		oldKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", entity.Role.Name, entity.Object.Name, entity.ObjectName))
+		v, err = kc.Txn.Load(oldKey)
 		if err == nil {
+			granteeKey = oldKey
 			idStr = v
 		}
 	}
@@ -1071,13 +1074,17 @@ func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvus
 				return err
 			}
 
-			idStr = crypto.MD5(k)
+			idStr = crypto.GranteeID(k)
 			err = kc.Txn.Save(k, idStr)
 			if err != nil {
 				log.Error("fail to allocate id when altering the grant", zap.Error(err))
 				return err
 			}
 		}
+	}
+	idStr, err = kc.migrateLegacyGranteeID(ctx, tenant, granteeKey, idStr)
+	if err != nil {
+		return err
 	}
 	k = funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, fmt.Sprintf("%s/%s", idStr, privilegeName))
 	_, err = kc.Txn.Load(k)
@@ -1109,6 +1116,59 @@ func (kc *Catalog) AlterGrant(ctx context.Context, tenant string, entity *milvus
 	return common.NewIgnorableError(fmt.Errorf("the privilege[%s] has been granted", privilegeName))
 }
 
+func (kc *Catalog) migrateLegacyGranteeID(ctx context.Context, tenant string, granteeKey string, idStr string) (string, error) {
+	if !isLegacyGranteeID(idStr) {
+		return idStr, nil
+	}
+
+	newID := crypto.GranteeID(granteeKey)
+	if idStr == newID {
+		return idStr, nil
+	}
+
+	oldGranteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, idStr)
+	oldGranteeIDPrefix := oldGranteeIDKey + "/"
+	idKeys, idValues, err := kc.Txn.LoadWithPrefix(oldGranteeIDPrefix)
+	if err != nil {
+		log.Warn("fail to load legacy grantee id entries",
+			zap.String("key", oldGranteeIDKey), zap.Error(err))
+		return "", err
+	}
+
+	saves := map[string]string{granteeKey: newID}
+	for i, idKey := range idKeys {
+		privilegeName := typeutil.After(idKey, oldGranteeIDPrefix)
+		if privilegeName == "" {
+			log.Warn("failed to extract privilege name from legacy grantee id key",
+				zap.String("idKey", idKey), zap.String("prefix", oldGranteeIDPrefix))
+			continue
+		}
+		saves[funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, fmt.Sprintf("%s/%s", newID, privilegeName))] = idValues[i]
+	}
+
+	if err := kc.Txn.MultiSaveAndRemove(saves, nil); err != nil {
+		log.Warn("fail to migrate legacy grantee id",
+			zap.String("granteeKey", granteeKey),
+			zap.String("oldID", idStr),
+			zap.String("newID", newID),
+			zap.Error(err))
+		return "", err
+	}
+	return newID, nil
+}
+
+func isLegacyGranteeID(idStr string) bool {
+	if len(idStr) != 16 {
+		return false
+	}
+	for _, ch := range idStr {
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') && (ch < 'A' || ch > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
 func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvuspb.GrantEntity) ([]*milvuspb.GrantEntity, error) {
 	var entities []*milvuspb.GrantEntity
 
@@ -1120,13 +1180,14 @@ func (kc *Catalog) ListGrant(ctx context.Context, tenant string, entity *milvusp
 			return nil
 		}
 		granteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, v)
-		keys, values, err := kc.Txn.LoadWithPrefix(granteeIDKey)
+		granteeIDPrefix := granteeIDKey + "/"
+		keys, values, err := kc.Txn.LoadWithPrefix(granteeIDPrefix)
 		if err != nil {
-			log.Error("fail to load the grantee ids", zap.String("key", granteeIDKey), zap.Error(err))
+			log.Error("fail to load the grantee ids", zap.String("key", granteeIDPrefix), zap.Error(err))
 			return err
 		}
 		for i, key := range keys {
-			granteeIDInfos := typeutil.AfterN(key, granteeIDKey+"/", "/")
+			granteeIDInfos := typeutil.AfterN(key, granteeIDPrefix, "/")
 			if len(granteeIDInfos) != 1 {
 				log.Warn("invalid grantee id", zap.String("string", key), zap.String("sub_string", granteeIDKey))
 				continue
@@ -1217,9 +1278,43 @@ func (kc *Catalog) DeleteGrant(ctx context.Context, tenant string, role *milvusp
 		log.Warn("fail to load grant privilege entities", zap.String("key", k), zap.Error(err))
 		return err
 	}
-	for _, v := range values {
-		granteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, v+"/")
-		removeKeys = append(removeKeys, granteeIDKey)
+	removedIDOrder := make([]string, 0, len(values))
+	removedIDs := make(map[string]struct{})
+	for _, idStr := range values {
+		if _, ok := removedIDs[idStr]; ok {
+			continue
+		}
+		removedIDs[idStr] = struct{}{}
+		removedIDOrder = append(removedIDOrder, idStr)
+	}
+	if len(removedIDOrder) > 0 {
+		granteePrefix := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, "") + "/"
+		keys, allValues, err := kc.Txn.LoadWithPrefix(granteePrefix)
+		if err != nil {
+			log.Warn("fail to load all grant privilege entities", zap.String("key", granteePrefix), zap.Error(err))
+			return err
+		}
+		survivingIDs := make(map[string]bool)
+		for i, key := range keys {
+			if i >= len(allValues) {
+				continue
+			}
+			idStr := allValues[i]
+			if _, removed := removedIDs[idStr]; !removed {
+				continue
+			}
+			grantInfos := typeutil.AfterN(key, granteePrefix, "/")
+			if len(grantInfos) != 3 || grantInfos[0] != role.Name {
+				survivingIDs[idStr] = true
+			}
+		}
+		for _, idStr := range removedIDOrder {
+			if survivingIDs[idStr] {
+				continue
+			}
+			granteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, idStr+"/")
+			removeKeys = append(removeKeys, granteeIDKey)
+		}
 	}
 
 	if err = kc.Txn.MultiSaveAndRemoveWithPrefix(nil, removeKeys); err != nil {
@@ -1244,13 +1339,14 @@ func (kc *Catalog) ListPolicy(ctx context.Context, tenant string) ([]string, err
 			continue
 		}
 		granteeIDKey := funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, values[i])
-		idKeys, _, err := kc.Txn.LoadWithPrefix(granteeIDKey)
+		granteeIDPrefix := granteeIDKey + "/"
+		idKeys, _, err := kc.Txn.LoadWithPrefix(granteeIDPrefix)
 		if err != nil {
-			log.Error("fail to load the grantee ids", zap.String("key", granteeIDKey), zap.Error(err))
+			log.Error("fail to load the grantee ids", zap.String("key", granteeIDPrefix), zap.Error(err))
 			return []string{}, err
 		}
 		for _, idKey := range idKeys {
-			granteeIDInfos := typeutil.AfterN(idKey, granteeIDKey+"/", "/")
+			granteeIDInfos := typeutil.AfterN(idKey, granteeIDPrefix, "/")
 			if len(granteeIDInfos) != 1 {
 				log.Warn("invalid grantee id", zap.String("string", idKey), zap.String("sub_string", granteeIDKey))
 				continue

--- a/internal/metastore/kv/rootcoord/kv_catalog_test.go
+++ b/internal/metastore/kv/rootcoord/kv_catalog_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/milvus-io/milvus-proto/go-api/v2/schemapb"
 	"github.com/milvus-io/milvus/internal/kv"
 	etcdkv "github.com/milvus-io/milvus/internal/kv/etcd"
+	memkv "github.com/milvus-io/milvus/internal/kv/mem"
 	"github.com/milvus-io/milvus/internal/kv/mocks"
 	"github.com/milvus-io/milvus/internal/metastore"
 	"github.com/milvus-io/milvus/internal/metastore/model"
@@ -2189,14 +2190,14 @@ func TestRBAC_Grant(t *testing.T) {
 		)
 
 		validRoleKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", validRole, object, objName))
-		validRoleValue := crypto.MD5(validRoleKey)
+		validRoleValue := crypto.GranteeID(validRoleKey)
 
 		invalidRoleKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", invalidRole, object, objName))
 		invalidRoleKeyWithDb := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", invalidRole, object, funcutil.CombineObjectName(util.DefaultDBName, objName)))
 
 		keyNotExistRoleKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", keyNotExistRole, object, objName))
 		keyNotExistRoleKeyWithDb := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", keyNotExistRole, object, funcutil.CombineObjectName(util.DefaultDBName, objName)))
-		keyNotExistRoleValueWithDb := crypto.MD5(keyNotExistRoleKeyWithDb)
+		keyNotExistRoleValueWithDb := crypto.GranteeID(keyNotExistRoleKeyWithDb)
 
 		errorSaveRoleKey := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", errorSaveRole, object, objName))
 		errorSaveRoleKeyWithDb := funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant, fmt.Sprintf("%s/%s/%s", errorSaveRole, object, funcutil.CombineObjectName(util.DefaultDBName, objName)))
@@ -2437,9 +2438,10 @@ func TestRBAC_Grant(t *testing.T) {
 			func(key string) []string {
 				// Mock kv_catalog.go:ListGrant:L871
 				if strings.Contains(key, GranteeIDPrefix) {
+					granteeIDKey := strings.TrimSuffix(key, "/")
 					return []string{
-						fmt.Sprintf("%s/%s", key, "PrivilegeLoad"),
-						fmt.Sprintf("%s/%s", key, "PrivilegeRelease"),
+						fmt.Sprintf("%s/%s", granteeIDKey, "PrivilegeLoad"),
+						fmt.Sprintf("%s/%s", granteeIDKey, "PrivilegeRelease"),
 					}
 				}
 
@@ -2542,10 +2544,11 @@ func TestRBAC_Grant(t *testing.T) {
 				contains := strings.Contains(key, GranteeIDPrefix)
 				if contains {
 					if secondLoadWithPrefixReturn.Load() {
+						granteeIDKey := strings.TrimSuffix(key, "/")
 						return []string{
-							fmt.Sprintf("%s/%s", key, "PrivilegeLoad"),
-							fmt.Sprintf("%s/%s", key, "PrivilegeRelease"),
-							fmt.Sprintf("%s/%s", key, "random/a/b/c"),
+							fmt.Sprintf("%s/%s", granteeIDKey, "PrivilegeLoad"),
+							fmt.Sprintf("%s/%s", granteeIDKey, "PrivilegeRelease"),
+							fmt.Sprintf("%s/%s", granteeIDKey, "random/a/b/c"),
 						}
 					}
 					return nil
@@ -2621,6 +2624,233 @@ func TestRBAC_Grant(t *testing.T) {
 				}
 			})
 		}
+	})
+}
+
+func TestRBAC_GranteeIDLengthAndLegacyCompatibility(t *testing.T) {
+	ctx := context.Background()
+	tenant := util.DefaultTenant
+	objectType := commonpb.ObjectType_Collection.String()
+
+	newGrantEntity := func(roleName string, objectName string, privilegeName string) *milvuspb.GrantEntity {
+		return &milvuspb.GrantEntity{
+			Role:       &milvuspb.RoleEntity{Name: roleName},
+			Object:     &milvuspb.ObjectEntity{Name: objectType},
+			ObjectName: objectName,
+			DbName:     util.DefaultDBName,
+			Grantor: &milvuspb.GrantorEntity{
+				User:      &milvuspb.UserEntity{Name: util.UserRoot},
+				Privilege: &milvuspb.PrivilegeEntity{Name: privilegeName},
+			},
+		}
+	}
+	granteeKey := func(roleName string, objectName string) string {
+		return funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
+			fmt.Sprintf("%s/%s/%s", roleName, objectType, funcutil.CombineObjectName(util.DefaultDBName, objectName)))
+	}
+	legacyGranteeKey := func(roleName string, objectName string) string {
+		return funcutil.HandleTenantForEtcdKey(GranteePrefix, tenant,
+			fmt.Sprintf("%s/%s/%s", roleName, objectType, objectName))
+	}
+	granteeIDKey := func(id string, privilegeName string) string {
+		return funcutil.HandleTenantForEtcdKey(GranteeIDPrefix, tenant, fmt.Sprintf("%s/%s", id, privilegeName))
+	}
+	requireGrantPrivileges := func(t *testing.T, c metastore.RootCoordCatalog, roleName string, objectName string, privileges ...string) {
+		t.Helper()
+
+		grants, err := c.ListGrant(ctx, tenant, &milvuspb.GrantEntity{
+			Role:       &milvuspb.RoleEntity{Name: roleName},
+			Object:     &milvuspb.ObjectEntity{Name: objectType},
+			ObjectName: objectName,
+			DbName:     util.DefaultDBName,
+		})
+		require.NoError(t, err)
+		require.Len(t, grants, len(privileges))
+
+		actual := make([]string, 0, len(grants))
+		for _, grant := range grants {
+			actual = append(actual, grant.GetGrantor().GetPrivilege().GetName())
+		}
+		assert.ElementsMatch(t, privileges, actual)
+	}
+
+	t.Run("new grant stores full length grantee id", func(t *testing.T) {
+		kv := memkv.NewMemoryKV()
+		c := &Catalog{Txn: kv}
+		roleName := "new_id_role"
+		objectName := "new_id_collection"
+		privilegeName := commonpb.ObjectPrivilege_PrivilegeInsert.String()
+
+		err := c.AlterGrant(ctx, tenant, newGrantEntity(roleName, objectName, privilegeName), milvuspb.OperatePrivilegeType_Grant)
+		require.NoError(t, err)
+
+		key := granteeKey(roleName, objectName)
+		id, err := kv.Load(key)
+		require.NoError(t, err)
+		assert.Len(t, id, 32)
+		assert.Equal(t, crypto.GranteeID(key), id)
+
+		user, err := kv.Load(granteeIDKey(id, privilegeName))
+		require.NoError(t, err)
+		assert.Equal(t, util.UserRoot, user)
+	})
+
+	t.Run("legacy grantee id lists migrates and revokes", func(t *testing.T) {
+		kv := memkv.NewMemoryKV()
+		c := &Catalog{Txn: kv}
+		roleName := "legacy_id_role"
+		objectName := "legacy_id_collection"
+		insertPrivilege := commonpb.ObjectPrivilege_PrivilegeInsert.String()
+		deletePrivilege := commonpb.ObjectPrivilege_PrivilegeDelete.String()
+		key := granteeKey(roleName, objectName)
+		legacyID := crypto.MD5(key)
+		require.Len(t, legacyID, 16)
+		require.NoError(t, kv.Save(key, legacyID))
+		legacyInsertKey := granteeIDKey(legacyID, insertPrivilege)
+		require.NoError(t, kv.Save(legacyInsertKey, util.UserRoot))
+
+		requireGrantPrivileges(t, c, roleName, objectName, "Insert")
+		policies, err := c.ListPolicy(ctx, tenant)
+		require.NoError(t, err)
+		require.Len(t, policies, 1)
+		assert.Equal(t, funcutil.PolicyForPrivilege(roleName, objectType, objectName, insertPrivilege, util.DefaultDBName), policies[0])
+
+		err = c.AlterGrant(ctx, tenant, newGrantEntity(roleName, objectName, deletePrivilege), milvuspb.OperatePrivilegeType_Grant)
+		require.NoError(t, err)
+
+		newID, err := kv.Load(key)
+		require.NoError(t, err)
+		require.Len(t, newID, 32)
+		assert.Equal(t, crypto.GranteeID(key), newID)
+		_, err = kv.Load(legacyInsertKey)
+		require.NoError(t, err)
+
+		user, err := kv.Load(granteeIDKey(newID, insertPrivilege))
+		require.NoError(t, err)
+		assert.Equal(t, util.UserRoot, user)
+		user, err = kv.Load(granteeIDKey(newID, deletePrivilege))
+		require.NoError(t, err)
+		assert.Equal(t, util.UserRoot, user)
+
+		err = c.AlterGrant(ctx, tenant, newGrantEntity(roleName, objectName, insertPrivilege), milvuspb.OperatePrivilegeType_Revoke)
+		require.NoError(t, err)
+		requireGrantPrivileges(t, c, roleName, objectName, "Delete")
+	})
+
+	t.Run("legacy no-db grantee id migrates", func(t *testing.T) {
+		kv := memkv.NewMemoryKV()
+		c := &Catalog{Txn: kv}
+		roleName := "legacy_no_db_role"
+		objectName := "legacy_no_db_collection"
+		insertPrivilege := commonpb.ObjectPrivilege_PrivilegeInsert.String()
+		deletePrivilege := commonpb.ObjectPrivilege_PrivilegeDelete.String()
+		key := legacyGranteeKey(roleName, objectName)
+		legacyID := crypto.MD5(key)
+		require.NoError(t, kv.Save(key, legacyID))
+		require.NoError(t, kv.Save(granteeIDKey(legacyID, insertPrivilege), util.UserRoot))
+
+		requireGrantPrivileges(t, c, roleName, objectName, "Insert")
+
+		err := c.AlterGrant(ctx, tenant, newGrantEntity(roleName, objectName, deletePrivilege), milvuspb.OperatePrivilegeType_Grant)
+		require.NoError(t, err)
+
+		newID, err := kv.Load(key)
+		require.NoError(t, err)
+		require.Len(t, newID, 32)
+		assert.Equal(t, crypto.GranteeID(key), newID)
+		requireGrantPrivileges(t, c, roleName, objectName, "Insert", "Delete")
+	})
+
+	t.Run("legacy grantee id revokes directly", func(t *testing.T) {
+		kv := memkv.NewMemoryKV()
+		c := &Catalog{Txn: kv}
+		roleName := "legacy_revoke_role"
+		objectName := "legacy_revoke_collection"
+		insertPrivilege := commonpb.ObjectPrivilege_PrivilegeInsert.String()
+		key := granteeKey(roleName, objectName)
+		legacyID := crypto.MD5(key)
+		require.NoError(t, kv.Save(key, legacyID))
+		legacyInsertKey := granteeIDKey(legacyID, insertPrivilege)
+		require.NoError(t, kv.Save(legacyInsertKey, util.UserRoot))
+
+		err := c.AlterGrant(ctx, tenant, newGrantEntity(roleName, objectName, insertPrivilege), milvuspb.OperatePrivilegeType_Revoke)
+		require.NoError(t, err)
+
+		newID, err := kv.Load(key)
+		require.NoError(t, err)
+		require.Len(t, newID, 32)
+		assert.Equal(t, crypto.GranteeID(key), newID)
+		_, err = kv.Load(legacyInsertKey)
+		require.NoError(t, err)
+		requireGrantPrivileges(t, c, roleName, objectName)
+	})
+
+	t.Run("legacy grantee id migration preserves other references", func(t *testing.T) {
+		kv := memkv.NewMemoryKV()
+		c := &Catalog{Txn: kv}
+		objectName := "legacy_shared_collection"
+		insertPrivilege := commonpb.ObjectPrivilege_PrivilegeInsert.String()
+		deletePrivilege := commonpb.ObjectPrivilege_PrivilegeDelete.String()
+		donorRole := "legacy_shared_donor"
+		victimRole := "legacy_shared_victim"
+		donorKey := granteeKey(donorRole, objectName)
+		victimKey := granteeKey(victimRole, objectName)
+		sharedLegacyID := crypto.MD5(donorKey)
+		require.NoError(t, kv.Save(donorKey, sharedLegacyID))
+		require.NoError(t, kv.Save(victimKey, sharedLegacyID))
+		legacyInsertKey := granteeIDKey(sharedLegacyID, insertPrivilege)
+		require.NoError(t, kv.Save(legacyInsertKey, util.UserRoot))
+
+		err := c.AlterGrant(ctx, tenant, newGrantEntity(victimRole, objectName, deletePrivilege), milvuspb.OperatePrivilegeType_Grant)
+		require.NoError(t, err)
+
+		victimID, err := kv.Load(victimKey)
+		require.NoError(t, err)
+		require.Len(t, victimID, 32)
+		assert.Equal(t, crypto.GranteeID(victimKey), victimID)
+		_, err = kv.Load(legacyInsertKey)
+		require.NoError(t, err)
+		requireGrantPrivileges(t, c, donorRole, objectName, "Insert")
+		requireGrantPrivileges(t, c, victimRole, objectName, "Insert", "Delete")
+	})
+
+	t.Run("role delete preserves other legacy grantee id references", func(t *testing.T) {
+		kv := memkv.NewMemoryKV()
+		c := &Catalog{Txn: kv}
+		insertPrivilege := commonpb.ObjectPrivilege_PrivilegeInsert.String()
+		deletedRole := "legacy_role_delete_victim"
+		untouchedRole := "legacy_role_delete_donor"
+		objectName := "legacy_role_delete_collection"
+		deletedKey := granteeKey(deletedRole, objectName)
+		untouchedKey := granteeKey(untouchedRole, objectName)
+		sharedLegacyID := crypto.MD5(untouchedKey)
+		require.NoError(t, kv.Save(deletedKey, sharedLegacyID))
+		require.NoError(t, kv.Save(untouchedKey, sharedLegacyID))
+		legacyInsertKey := granteeIDKey(sharedLegacyID, insertPrivilege)
+		require.NoError(t, kv.Save(legacyInsertKey, util.UserRoot))
+
+		err := c.DeleteGrant(ctx, tenant, &milvuspb.RoleEntity{Name: deletedRole})
+		require.NoError(t, err)
+
+		requireGrantPrivileges(t, c, untouchedRole, objectName, "Insert")
+		_, err = kv.Load(legacyInsertKey)
+		require.NoError(t, err)
+	})
+
+	t.Run("grantee id reads use exact id namespace", func(t *testing.T) {
+		kv := memkv.NewMemoryKV()
+		c := &Catalog{Txn: kv}
+		roleName := "legacy_prefix_role"
+		objectName := "legacy_prefix_collection"
+		key := granteeKey(roleName, objectName)
+		legacyID := "aaaaaaaaaaaaaaaa"
+		require.NoError(t, kv.Save(key, legacyID))
+		require.NoError(t, kv.Save(granteeIDKey(legacyID+"extra", commonpb.ObjectPrivilege_PrivilegeInsert.String()), util.UserRoot))
+
+		requireGrantPrivileges(t, c, roleName, objectName)
+		policies, err := c.ListPolicy(ctx, tenant)
+		require.NoError(t, err)
+		assert.Empty(t, policies)
 	})
 }
 

--- a/pkg/util/crypto/crypto.go
+++ b/pkg/util/crypto/crypto.go
@@ -46,3 +46,10 @@ func MD5(str string) string {
 	data := md5.Sum([]byte(str))
 	return hex.EncodeToString(data[:])[8:24]
 }
+
+// GranteeID returns the full 128-bit MD5 digest used for RBAC grantee-id keys.
+func GranteeID(str string) string {
+	// #nosec
+	data := md5.Sum([]byte(str))
+	return hex.EncodeToString(data[:])
+}

--- a/pkg/util/crypto/crypto_test.go
+++ b/pkg/util/crypto/crypto_test.go
@@ -1,9 +1,11 @@
 package crypto
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -44,4 +46,21 @@ func TestBcryptCost(t *testing.T) {
 
 func TestMD5(t *testing.T) {
 	assert.Equal(t, "67f48520697662a2", MD5("These pretzels are making me thirsty."))
+}
+
+func TestGranteeID(t *testing.T) {
+	id := GranteeID("These pretzels are making me thirsty.")
+	assert.Equal(t, "b0804ec967f48520697662a204f5fe72", id)
+	assert.Len(t, id, 32)
+}
+
+func TestGranteeIDUniqueness(t *testing.T) {
+	seen := make(map[string]struct{})
+	for i := 0; i < 4096; i++ {
+		key := fmt.Sprintf("root-coord/credential/grantee-privileges/role-%04d/Collection/default.collection-%04d", i, i)
+		id := GranteeID(key)
+		require.Len(t, id, 32)
+		require.NotContains(t, seen, id)
+		seen[id] = struct{}{}
+	}
 }


### PR DESCRIPTION
- Add a grantee-id specific full 128-bit MD5 helper and switch RBAC grantee-id writes to the full-length hex value while leaving the legacy `crypto.MD5` helper unchanged.
- Keep legacy 64-bit grantee-id parent values readable and lazily rewrite them on `AlterGrant` by copying existing child grant keys to the new full-length ID.
- Use slash-qualified child lookups and shared-ID-aware role cleanup so legacy collision compatibility does not let one grantee-id prefix match or delete another grantee-id namespace.

related: #49857
